### PR TITLE
feat: support publish to GPR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Publish to NPM/GPR
 on:
   release:
     types: [published]
@@ -26,3 +26,12 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish (GPR)
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes issue with internal project, due to NPM/Yarn scoping an entire registry to `@sourcetoad`. So this project is required to be published in parallel to GPR

```
error An unexpected error occurred: "https://npm.pkg.github.com/@sourcetoad%2fadd-badge: npm package \"add-badge\" does not exist under owner \"sourcetoad\"".
```