### PR TITLE
Updated matrix for new node version

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18, 19 ]
+        node: [ 16, 18, 20 ]
     name: Check Code (Node ${{ matrix.node }})
 
     steps:


### PR DESCRIPTION
This updates the test matrix to use Node 20 instead of 19, which was released on 4/18 and will be the next LTS release.