### PR TITLE
Path resolution fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sourcetoad/add-badge",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sourcetoad/add-badge",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@imagemagick/magick-wasm": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcetoad/add-badge",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/utils/initializeImageMagick.ts
+++ b/src/utils/initializeImageMagick.ts
@@ -1,11 +1,10 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 
 import { initializeImageMagick as baseInitializeImageMagick } from '@imagemagick/magick-wasm';
 
 export default async function initializeImageMagick(): Promise<void> {
   const wasmBytes = readFileSync(
-    resolve('node_modules/@imagemagick/magick-wasm/dist/magick.wasm'),
+    require.resolve('@imagemagick/magick-wasm/magick.wasm'),
   );
   await baseInitializeImageMagick(wasmBytes);
 }


### PR DESCRIPTION
Switches to require.resolve to make use of Node's built in package resolution rules rather than looking relative to the current path.