### PR TITLE
Add node 26 to CI

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 25]
+        node: [20, 22, 25, 26]
     name: Check Code (Node ${{ matrix.node }})
 
     steps:


### PR DESCRIPTION
Node 26 released today. Node 20 also reached EOL last week. Will open a follow up to remove support for it since it involves updating the package.json as well.